### PR TITLE
feat: Mobile Responsivity

### DIFF
--- a/src/components/molecules/LoggedMembersSection/index.js
+++ b/src/components/molecules/LoggedMembersSection/index.js
@@ -19,7 +19,7 @@ const LoggedMembers = ({
 }) => {
 	return (
 		<LoggedMembersContainer className="container">
-			<Row className="flex-nowrap w-100 ">
+			<Row className="flex-nowrap w-auto ">
 				<Col sm="auto" xs="auto" className="d-none d-sm-flex">
 					<MemberAvatar src={imageLink} />
 				</Col>
@@ -33,7 +33,7 @@ const LoggedMembers = ({
 					</Row>
 					<Row
 						style={{ marginTop: 8 }}
-						className="d-none d-sm-flex flex-nowrap flex-column flex-md-row"
+						className="d-sm-flex flex-nowrap flex-column flex-md-row"
 					>
 						{role && (
 							<DefaultLabel labelText={role} className="align-self-start" />

--- a/src/pages/Administration/Members/styles.js
+++ b/src/pages/Administration/Members/styles.js
@@ -66,6 +66,10 @@ const MembersComponent = styled.div`
       justify-content: space-between;
       align-items: flex-start;
     }
+    padding-left:0px;
+    padding-right: 0px;
+    padding-top: 10px;
+    padding-bottom: 5px;
   }
 `;
 const ActionsDiv = styled.div`

--- a/src/pages/Administration/Roles/styles.js
+++ b/src/pages/Administration/Roles/styles.js
@@ -8,7 +8,7 @@ const RolesComponent = styled.div`
 
     display: flex;
     flex-direction: column;
-    padding: 30px 16px;
+    padding: 30px 20px;
 
     .iconWithTitle{
         width: 100%;
@@ -107,7 +107,12 @@ const RolesComponent = styled.div`
         }
     }
 
-
+    @media (max-width: 720px) {
+    padding-left:0px;
+    padding-right: 0px;
+    padding-top: 10px;
+    padding-bottom: 5px;
+    }
 `;
 
 export  { RolesComponent };

--- a/src/pages/Administration/Roles/styles.js
+++ b/src/pages/Administration/Roles/styles.js
@@ -8,7 +8,7 @@ const RolesComponent = styled.div`
 
     display: flex;
     flex-direction: column;
-    padding: 30px 20px;
+    padding: 30px 16px;
 
     .iconWithTitle{
         width: 100%;

--- a/src/pages/Administration/Tribes/styles.js
+++ b/src/pages/Administration/Tribes/styles.js
@@ -8,7 +8,7 @@ const TribesComponent = styled.div`
 
 	display: flex;
 	flex-direction: column;
-	padding: 30px 20px;
+	padding: 30px 16px;
 
 	.iconWithTitle {
 		width: 100%;

--- a/src/pages/Administration/Tribes/styles.js
+++ b/src/pages/Administration/Tribes/styles.js
@@ -8,7 +8,7 @@ const TribesComponent = styled.div`
 
 	display: flex;
 	flex-direction: column;
-	padding: 30px 16px;
+	padding: 30px 20px;
 
 	.iconWithTitle {
 		width: 100%;
@@ -110,6 +110,12 @@ const TribesComponent = styled.div`
 			color: #c70000;
 		}
 	}
+	@media (max-width: 720px) {
+    padding-left:0px;
+    padding-right: 0px;
+    padding-top: 10px;
+    padding-bottom: 5px;
+    }
 `;
 
 export { TribesComponent };

--- a/src/pages/Administration/UpdateNews/styles.js
+++ b/src/pages/Administration/UpdateNews/styles.js
@@ -12,7 +12,10 @@ const UpdatedNewsComponent = styled.div`
   flex-direction: column;
 
   @media (max-width: 720px) {
-      padding: 30px 16px;
+      padding-top: 10px;
+      padding-bottom: 5px;
+      padding-right: 0px;
+      padding-left: 0px;
   }
 
   .titleArea {
@@ -73,7 +76,6 @@ const UpdatedNewsComponent = styled.div`
       width: 100%;
       grid-template-columns: 1fr;
       row-gap: 30px;
-      padding: 16px;
     }
   }
 `;

--- a/src/pages/Administration/UpdateNews/styles.js
+++ b/src/pages/Administration/UpdateNews/styles.js
@@ -11,6 +11,10 @@ const UpdatedNewsComponent = styled.div`
   display: flex;
   flex-direction: column;
 
+  @media (max-width: 720px) {
+      padding: 30px 16px;
+  }
+
   .titleArea {
     display: flex;
     justify-content: flex-start;
@@ -69,6 +73,7 @@ const UpdatedNewsComponent = styled.div`
       width: 100%;
       grid-template-columns: 1fr;
       row-gap: 30px;
+      padding: 16px;
     }
   }
 `;

--- a/src/pages/HourConsultation/styles.js
+++ b/src/pages/HourConsultation/styles.js
@@ -4,7 +4,8 @@ const HoursConsultationComponent = styled.div`
   width: 100%;
   min-height: 100vh;
 
-  padding: 20px;
+  padding-top: 10px;
+  padding-bottom: 5px;
 
   display: flex;
   flex-direction: column;

--- a/src/pages/Login/style.js
+++ b/src/pages/Login/style.js
@@ -18,7 +18,10 @@ const LoginComponent = styled.div`
         left: 50vw;
         top: 50vh;
         transform: translate(-50%, -50%);
-    }
+
+        @media(max-width: 600px){
+            width: 80%;
+        }
 
     .logo {
         position: absolute;
@@ -26,6 +29,10 @@ const LoginComponent = styled.div`
         left: 50%;
         top: 25%;
         transform: translateX(-50%);
+
+        @media(max-width: 350px){
+            width: 90%;
+        }
     }
 
     .loginButton {
@@ -43,7 +50,6 @@ const LoginComponent = styled.div`
         top: 70%;
         text-decoration-line: underline;
         color: #FFD100;
-    }
-`;
+    }`;
 
 export { LoginComponent };


### PR DESCRIPTION
- Reduzir a largura do bloco de login para que ele ocupe 80% da tela em todos os mobile;

- Fazer com que o nome do membro seja disposto por completo junto de seu cargo e tribo, na pagina “consulta de horas”;

- Reduzir o padding nas páginas descriminadas.